### PR TITLE
[채용수 241103] 알고리즘 문제 풀이

### DIFF
--- a/Yachaeyong/baekjoon/b1439.py
+++ b/Yachaeyong/baekjoon/b1439.py
@@ -1,0 +1,11 @@
+# 뒤집기
+import sys
+
+S = sys.stdin.readline().rstrip()
+
+cnt = 0
+for i in range(1, len(S)):
+    if S[i] != S[i-1]:
+        cnt += 1
+
+print((cnt+1)//2)

--- a/Yachaeyong/baekjoon/b2839.py
+++ b/Yachaeyong/baekjoon/b2839.py
@@ -1,0 +1,24 @@
+# 설탕 배달
+
+N = int(input())
+# 1. 그리디
+cnt = 0
+while N >= 0:
+    if N % 5 == 0:
+        cnt += N //5
+        print(cnt)
+        break
+    cnt += 1
+    N -= 3
+else:
+    print(-1)
+
+# # 2. dp
+# INF = int(1e9)
+# dp = [INF] * 5001
+#
+# dp[3] = dp[5] = 1
+# for i in range(6, N + 1):
+#     dp[i] = min(dp[i - 3], dp[i - 5]) + 1
+#
+# print(dp[N] if dp[N] < INF else -1)


### PR DESCRIPTION
# 알고리즘 문제 풀이

<!-- 문제 별로 풀이를 정리하고 싶다면 정리합니다.-->

## [백준 - 뒤집기](https://www.acmicpc.net/problem/1439)

### 풀이
숫자 다를 때 마다 +1 해주고 뒤집기 끝나면 cnt +1 하고 2로 나눈 몫을 구하면 정답.

## [백준 - 설탕 배달](https://www.acmicpc.net/problem/2839)

### 풀이
그리디랑 dp 두 방법으로 풀리는 문제. 일단 최대한 5kg으로 옮기는게 최소 가방 갯수로 옮길 수 있으므로 5로 나눠지면 5로 나눈 몫을 더하고 5의 배수가 아니면 5의 배수일때 까지 -3kg해주면서 최적해 찾음.
디피는 3과 5의 배수일때만 보면 되므로 6부터 끝까지 dp 돌면서 해당 인덱스 -3 과 -5의 dp값을 보게되면 3이나 5의 배수가 아닌 경우 INF일테니 마지막에 dp[N]이 INF미만인 경우에만 출력.
